### PR TITLE
First column in month-by-hour table, corrected: hour instead of day

### DIFF
--- a/helper/table.php
+++ b/helper/table.php
@@ -145,7 +145,7 @@ class helper_plugin_statdisplay_table extends DokuWiki_Plugin {
         $this->R->tablerow_close();
 
         $this->R->tablerow_open();
-        $this->head($this->getLang('day'));
+        $this->head($this->getLang($by));
         $this->head($this->getLang('hits'), 2);
         $this->head($this->getLang('media'), 2);
         $this->head($this->getLang('pages'), 2);

--- a/lang/de/lang.php
+++ b/lang/de/lang.php
@@ -20,6 +20,7 @@ $lang['t_traffichour']         = 'Statistik des stündlichen Datenverkehrs für 
 $lang['t_usertraffic']         = '7 Tage Usertraffic';
 $lang['month']                 = 'Monat';
 $lang['day']                   = 'Tag';
+$lang['hour']                  = 'Stunde';
 $lang['dailyavg']              = 'Täglicher Durchschnitt';
 $lang['totals']                = 'Monatliche Gesamtwerte';
 $lang['all']                   = 'Alle';

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -15,6 +15,7 @@ $lang['t_usertraffic'] = '7 Day User Traffic';
 
 $lang['month']    = 'Month';
 $lang['day']      = 'Day';
+$lang['hour']     = 'Hour';
 $lang['dailyavg'] = 'Daily Average';
 $lang['totals']   = 'Monthly Totals';
 

--- a/lang/fr/lang.php
+++ b/lang/fr/lang.php
@@ -19,6 +19,7 @@ $lang['t_traffichour']         = 'Trafic horaire pour %s';
 $lang['t_usertraffic']         = 'Trafic utilisateur sur 7 jours';
 $lang['month']                 = 'Mois';
 $lang['day']                   = 'Jour';
+$lang['hour']                  = 'Heure';
 $lang['dailyavg']              = 'Moyenne quotidienne';
 $lang['totals']                = 'Totaux mensuels';
 $lang['all']                   = 'Tout';

--- a/lang/ru/lang.php
+++ b/lang/ru/lang.php
@@ -19,6 +19,7 @@ $lang['t_traffichour']         = 'Часовая статистика трафи
 $lang['t_usertraffic']         = 'Загрузки пользователей за 7 дней';
 $lang['month']                 = 'Месяц';
 $lang['day']                   = 'День';
+$lang['hour']                  = 'час';
 $lang['dailyavg']              = 'Среднее за день';
 $lang['totals']                = 'Итог за месяц';
 $lang['all']                   = 'Все';


### PR DESCRIPTION
When displaying the "month by hour" statistics table, the caption of the first column should be made to "hour" instead of "day" (row values are from 0 to 23).
