### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/action.php
+++ b/action.php
@@ -10,7 +10,7 @@ if(!defined('DOKU_INC')) die();
  */
 class action_plugin_statdisplay extends DokuWiki_Action_Plugin {
 
-    function register($controller) {
+    function register(Doku_Event_Handler $controller) {
         $controller->register_hook('INDEXER_TASKS_RUN','AFTER', $this, 'handle_run');
     }
 

--- a/syntax.php
+++ b/syntax.php
@@ -42,7 +42,7 @@ class syntax_plugin_statdisplay extends DokuWiki_Syntax_Plugin {
     /**
      * Handle the match
      */
-    function handle($match, $state, $pos, &$handler) {
+    function handle($match, $state, $pos, Doku_Handler $handler) {
         $command = trim(substr($match, 14 ,-2));
         list($command, $params) = explode('?', $command);
         $params = explode(' ',$params);
@@ -74,7 +74,7 @@ class syntax_plugin_statdisplay extends DokuWiki_Syntax_Plugin {
     /**
      * Create output
      */
-    function render($format, &$renderer, $data) {
+    function render($format, Doku_Renderer $renderer, $data) {
         if($format != 'xhtml') return true;
         $command = $data['command'];
         $graph   = $data['graph'];


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.