### PR TITLE
Actually process (most of) the log file

### DIFF
--- a/helper/log.php
+++ b/helper/log.php
@@ -57,7 +57,7 @@ class helper_plugin_statdisplay_log extends DokuWiki_Plugin {
         $pos = 0;
         if(isset($this->logdata['_logpos'])) $pos = $this->logdata['_logpos'];
         if($pos > $size) $pos = 0;
-        if($pos && ( ($size - $pos) > ($this->getConf('lines') * 150) )) return 0; // we want to have some minimal log data
+        if($pos && ( ($size - $pos) < ($this->getConf('lines') * 150) )) return 0; // we want to have some minimal log data
 
         if(!$this->lock()) return 0;
 


### PR DESCRIPTION
The current code stops log file analysis if $size-$pos is larger than the amount of lines (* 150 characters) to process in one run. This leads to only the first $lines being processed if a log file is larger than $lines * 150 bytes (which is usually the case). Changing the 'greater than' sign to a 'smaller than' sign fixes this issue. (However, the plugin will still nearly never analyze the most recent entries)