### PR TITLE
Fix warnings in PHP 8

### DIFF
--- a/graph.php
+++ b/graph.php
@@ -14,6 +14,6 @@ require_once(DOKU_INC . 'inc/init.php');
 $graph = plugin_load('helper', 'statdisplay_graph');
 $graph->sendgraph(
     $_REQUEST['graph'],
-    $_REQUEST['f'],
-    $_REQUEST['to']
+    $_REQUEST['f'] ?? '',
+    $_REQUEST['t'] ?? ''
 );

--- a/helper/graph.php
+++ b/helper/graph.php
@@ -70,15 +70,15 @@ class helper_plugin_statdisplay_graph extends DokuWiki_Plugin
         $visitors = array();
 
         foreach ($this->log->logdata as $month => $data) {
-            if ($month{0} == '_') continue;
+            if ($month[0] == '_') continue;
             if ($from && $month < $from) continue;
             if ($to && $month > $to) break;
 
             $times[] = $month;
-            $pages[] = $data['page']['all']['count'];
-            $media[] = $data['media']['all']['count'];
-            $hits[] = $data['hits']['all']['count'];
-            $visitors[] = $data['hits']['all']['visitor'];
+            $pages[] = $data['page']['all']['count'] ?? 0;
+            $media[] = $data['media']['all']['count'] ?? 0;
+            $hits[] = $data['hits']['all']['count'] ?? 0;
+            $visitors[] = $data['hits']['all']['visitor'] ?? 0;
         }
 
         $title = $this->getLang('t_summary');

--- a/helper/table.php
+++ b/helper/table.php
@@ -313,18 +313,21 @@ class helper_plugin_statdisplay_table extends DokuWiki_Plugin
         $this->R->tablerow_close();
 
         foreach ((array)$this->log->logdata as $month => $data) {
-            if ($month{0} == '_') continue;
-            if ($from && $month < $from) continue;
-            if ($to && $month > $to) break;
+            if ($month[0] == '_') continue;
+            if (!empty($from) && $month < $from) continue;
+            if (!empty($to) && $month > $to) break;
+
+
+
 
             $this->R->tablerow_open();
 
             $this->cell($month, 1, false); // Month
             // ---- averages ----
-            $this->cell(round($this->log->avg($data['hits']['day'], 'count'))); // Hits
-            $this->cell(round($this->log->avg($data['media']['day'], 'count'))); // Files
-            $this->cell(round($this->log->avg($data['page']['day'], 'count'))); // Pages
-            $this->cell(round($this->log->avg($data['hits']['day'], 'visitor'))); // Visits
+            $this->cell(round($this->log->avg($data['hits']['day'] ?? [], 'count'))); // Hits
+            $this->cell(round($this->log->avg($data['media']['day'] ?? [], 'count'))); // Files
+            $this->cell(round($this->log->avg($data['page']['day'] ?? [], 'count'))); // Pages
+            $this->cell(round($this->log->avg($data['hits']['day'] ?? [], 'visitor'))); // Visits
             // ---- totals ----
             $this->cell($data['hits']['all']['count']); // Hits
             $this->cell($data['media']['all']['count']); // Files

--- a/syntax.php
+++ b/syntax.php
@@ -36,7 +36,7 @@ class syntax_plugin_statdisplay extends DokuWiki_Syntax_Plugin
     function handle($match, $state, $pos, Doku_Handler $handler)
     {
         $command = trim(substr($match, 14, -2));
-        list($command, $params) = explode('?', $command);
+        list($command, $params) = array_pad(explode('?', $command), 2, '');
         $params = explode(' ', $params);
 
         $params = array_map('trim', $params);
@@ -51,7 +51,7 @@ class syntax_plugin_statdisplay extends DokuWiki_Syntax_Plugin
         }
 
         // remaining params are dates
-        list($from, $to) = array_values($params);
+        list($from, $to) = array_pad(array_values($params), 2, '');
 
         return [
             'command' => $command,
@@ -93,7 +93,7 @@ class syntax_plugin_statdisplay extends DokuWiki_Syntax_Plugin
     private function cleanDate($date)
     {
         $months = array('', 'jan', 'feb', 'mar', 'apr', 'may', 'jun', 'jul', 'aug', 'sep', 'oct', 'nov', 'dec');
-        list($month, $year) = explode('_', strtolower($date));
+        list($month, $year) = array_pad(explode('_', strtolower($date)), 2, '');
         $year = (int)$year;
         if ($year < 2000 || $year > 2050) return '';
         $month = array_search($month, $months);


### PR DESCRIPTION
Mostly `isset()` checks and variable initializations.

Fixes #55 